### PR TITLE
Provide faster memchr for windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "memchr"
 version = "0.1.5"  #:version
-authors = ["Andrew Gallant <jamslam@gmail.com>"]
+authors = ["Andrew Gallant <jamslam@gmail.com>", "bluss"]
 description = "Safe interface to memchr."
 documentation = "http://burntsushi.net/rustdoc/memchr/"
 homepage = "https://github.com/BurntSushi/rust-memchr"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,16 +297,44 @@ mod tests {
     }
 
     #[test]
-    fn qc_correct_reversed() {
-        fn prop(a: Vec<u8>) -> bool {
+    fn qc_correct_memchr() {
+        fn prop(v: Vec<u8>, offset: u8) -> bool {
+            // test all pointer alignments
+            let uoffset = (offset & 0xF) as usize;
+            let data = if uoffset <= v.len() {
+                &v[uoffset..]
+            } else {
+                &v[..]
+            };
             for byte in 0..256u32 {
                 let byte = byte as u8;
-                if memrchr(byte, &a) != a.iter().rposition(|elt| *elt == byte) {
+                if memchr(byte, &data) != data.iter().position(|elt| *elt == byte) {
                     return false;
                 }
             }
             true
         }
-        quickcheck::quickcheck(prop as fn(Vec<u8>) -> bool);
+        quickcheck::quickcheck(prop as fn(Vec<u8>, u8) -> bool);
+    }
+
+    #[test]
+    fn qc_correct_memrchr() {
+        fn prop(v: Vec<u8>, offset: u8) -> bool {
+            // test all pointer alignments
+            let uoffset = (offset & 0xF) as usize;
+            let data = if uoffset <= v.len() {
+                &v[uoffset..]
+            } else {
+                &v[..]
+            };
+            for byte in 0..256u32 {
+                let byte = byte as u8;
+                if memrchr(byte, &data) != data.iter().rposition(|elt| *elt == byte) {
+                    return false;
+                }
+            }
+            true
+        }
+        quickcheck::quickcheck(prop as fn(Vec<u8>, u8) -> bool);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,10 +4,10 @@ to the corresponding functions in `libc`.
 */
 
 #![deny(missing_docs)]
+#![allow(unused_imports)]
 
 extern crate libc;
 
-use libc::funcs::c95::string;
 use libc::c_void;
 use libc::{c_int, size_t};
 
@@ -31,17 +31,35 @@ use libc::{c_int, size_t};
 /// assert_eq!(memchr(b'k', haystack), Some(8));
 /// ```
 pub fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
-    let p = unsafe {
-        string::memchr(
-            haystack.as_ptr() as *const c_void,
-            needle as c_int,
-            haystack.len() as size_t)
-    };
-    if p.is_null() {
-        None
-    } else {
-        Some(p as usize - (haystack.as_ptr() as usize))
+    // libc memchr
+    #[cfg(any(not(target_os = "windows"),
+              not(any(target_pointer_width = "32",
+                      target_pointer_width = "64"))))]
+    fn memchr_specific(needle: u8, haystack: &[u8]) -> Option<usize> {
+        use libc::memchr as libc_memchr;
+
+        let p = unsafe {
+            libc_memchr(
+                haystack.as_ptr() as *const c_void,
+                needle as c_int,
+                haystack.len() as size_t)
+        };
+        if p.is_null() {
+            None
+        } else {
+            Some(p as usize - (haystack.as_ptr() as usize))
+        }
     }
+
+    // use fallback on windows, since it's faster
+    #[cfg(all(target_os = "windows",
+              any(target_pointer_width = "32",
+                  target_pointer_width = "64")))]
+    fn memchr_specific(needle: u8, haystack: &[u8]) -> Option<usize> {
+        fallback::memchr(needle, haystack)
+    }
+
+    memchr_specific(needle, haystack)
 }
 
 /// A safe interface to `memrchr`.
@@ -95,7 +113,8 @@ pub fn memrchr(needle: u8, haystack: &[u8]) -> Option<usize> {
     memrchr_specific(needle, haystack)
 }
 
-#[cfg(not(target_os = "linux"))]
+#[cfg(all(not(target_os = "linux"),
+          any(target_pointer_width = "32", target_pointer_width = "64")))]
 mod fallback {
     use std::cmp;
 
@@ -140,6 +159,53 @@ mod fallback {
         rep
     }
 
+    /// Return the first index matching the byte `a` in `text`.
+    pub fn memchr(x: u8, text: &[u8]) -> Option<usize> {
+        // Scan for a single byte value by reading two `usize` words at a time.
+        //
+        // Split `text` in three parts
+        // - unaligned inital part, before the first word aligned address in text
+        // - body, scan by 2 words at a time
+        // - the last remaining part, < 2 word size
+        let len = text.len();
+        let ptr = text.as_ptr();
+
+        // search up to an aligned boundary
+        let align = (ptr as usize) & (USIZE_BYTES - 1);
+        let mut offset;
+        if align > 0 {
+            offset = cmp::min(USIZE_BYTES - align, len);
+            if let Some(index) = text[..offset].iter().position(|elt| *elt == x) {
+                return Some(index);
+            }
+        } else {
+            offset = 0;
+        }
+
+        // search the body of the text
+        let repeated_x = repeat_byte(x);
+
+        if len >= 2 * USIZE_BYTES {
+            while offset <= len - 2 * USIZE_BYTES {
+                unsafe {
+                    let u = *(ptr.offset(offset as isize) as *const usize);
+                    let v = *(ptr.offset((offset + USIZE_BYTES) as isize) as *const usize);
+
+                    // break if there is a matching byte
+                    let zu = contains_zero_byte(u ^ repeated_x);
+                    let zv = contains_zero_byte(v ^ repeated_x);
+                    if zu || zv {
+                        break;
+                    }
+                }
+                offset += USIZE_BYTES * 2;
+            }
+        }
+
+        // find the byte after the point the body loop stopped
+        text[offset..].iter().position(|elt| *elt == x).map(|i| offset + i)
+    }
+
     /// Return the last index matching the byte `a` in `text`.
     pub fn memrchr(x: u8, text: &[u8]) -> Option<usize> {
         // Scan for a single byte value by reading two `usize` words at a time.
@@ -181,7 +247,7 @@ mod fallback {
             offset -= 2 * USIZE_BYTES;
         }
 
-        // find the byte after the point the body loop stopped
+        // find the byte before the point the body loop stopped
         text[..offset].iter().rposition(|elt| *elt == x)
     }
 }


### PR DESCRIPTION
Follow up PR #3 with the same algorithm in forward search, manually implemented
memchr searching two usize at a time. This should be better than some libc implementations
on windows, so we enable this by default there.

I'm not very happy with the tangle of configuration conditions.