### PR TITLE
dependencies: require libc 0.2.4 as minimum

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ name = "memchr"
 bench = false
 
 [dependencies]
-libc = "0.2.4"
+libc = "^0.2.4"
 
 [dev-dependencies]
 quickcheck = "0.2"


### PR DESCRIPTION
Many crates depend on libc.  Having the dependency here require
exactly 0.2.4 causes problems when some other requires a version
newer than 0.2.4.  By sepcifying '^0.2.4' we allow any 0.2.x
version where `x > 4`.