### PR TITLE
Add optional no_std support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ rust:
   - beta
   - nightly
 script:
+  - cargo build --verbose --no-default-features
   - cargo build --verbose
   - cargo test --verbose
   - cargo doc

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,12 @@ license = "Unlicense/MIT"
 name = "memchr"
 bench = false
 
+[features]
+default = ["use_std"]
+use_std = ["libc/use_std"]
+
 [dependencies]
-libc = "0.2.18"
+libc = { version = "0.2.18", default-features = false }
 
 [dev-dependencies]
 quickcheck = "0.4.1"

--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ Dual-licensed under MIT or the [UNLICENSE](http://unlicense.org).
 
 [https://docs.rs/memchr](https://docs.rs/memchr)
 
+### no_std
+
+memchr links to the standard library by default, but you can disable the
+`use_std` feature if you want to use it in a `#![no_std]` crate:
+
+```toml
+[dependencies]
+memchr = { version = "1.0", default-features = false }
+```
 
 ### Performance
 


### PR DESCRIPTION
This still uses std by default, for compatibility with versions of Rust older than 1.6.0.  If compatibility with old versions is not a concern, this could be simplified to remove the optional feature and instead set `no_std` unconditionally.