### PR TITLE
fallback: fix variable name in docstrings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -424,7 +424,7 @@ mod fallback {
         contains_zero_byte, repeat_byte,
     };
 
-    /// Return the first index matching the byte `a` in `text`.
+    /// Return the first index matching the byte `x` in `text`.
     pub fn memchr(x: u8, text: &[u8]) -> Option<usize> {
         // Scan for a single byte value by reading two `usize` words at a time.
         //
@@ -473,7 +473,7 @@ mod fallback {
         text[offset..].iter().position(|elt| *elt == x).map(|i| offset + i)
     }
 
-    /// Return the last index matching the byte `a` in `text`.
+    /// Return the last index matching the byte `x` in `text`.
     pub fn memrchr(x: u8, text: &[u8]) -> Option<usize> {
         // Scan for a single byte value by reading two `usize` words at a time.
         //


### PR DESCRIPTION
I intend to make the same PR for `src/libcore/slice/memchr.rs` in rust-lang/rust. If you are OK with this, I will r=you there.