### PR TITLE
rollup + fix ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,3 +5,6 @@ rust:
   - beta
   - nightly
 script: ci/script.sh
+branches:
+  only:
+    - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,4 @@ rust:
   - stable
   - beta
   - nightly
-script:
-  - cargo build --verbose --no-default-features
-  - cargo build --verbose
-  - cargo test --verbose
-  - cargo doc
-  - if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
-      cargo bench --verbose;
-    fi
+script: ci/script.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ use_std = ["libc", "libc/use_std"]
 libc = { version = "0.2.18", default-features = false, optional = true }
 
 [dev-dependencies]
-quickcheck = { version = "0.5", default-features = false }
+quickcheck = { version = "0.6", default-features = false }
 
 [profile.test]
 opt-level = 3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,10 +10,11 @@ install:
   - SET PATH=%PATH%;C:\MinGW\bin
   - rustc -V
   - cargo -V
-
 build: false
-
 test_script:
   - cargo build --verbose
   - cargo test --verbose
   - cargo bench --verbose
+branches:
+  only:
+    - master

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -ex
+
+cargo build --verbose
+cargo doc --verbose
+
+# If we're testing on an older version of Rust, then only check that we
+# can build the crate. This is because the dev dependencies might be updated
+# more frequently, and therefore might require a newer version of Rust.
+#
+# This isn't ideal. It's a compromise.
+if [ "$TRAVIS_RUST_VERSION" = "1.12.0" ]; then
+  exit
+fi
+
+cargo test --verbose
+if [ "$TRAVIS_RUST_VERSION" = "nightly" ]; then
+  cargo bench --verbose --no-run
+fi


### PR DESCRIPTION
This rolls up #25 and fixes CI such that tests are no longer run on Rust 1.12 (but we still check compilation).