### PR TITLE
Remove libc dependency on wasm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ bench = false
 default = ["use_std", "libc"]
 use_std = ["libc", "libc/use_std"]
 
-[dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 libc = { version = "0.2.18", default-features = false, optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
It's already not being linked:

https://github.com/BurntSushi/rust-memchr/blob/c9a7e713d65448541ca373734f3cd18e11d29c1d/src/lib.rs#L16-L17

But because it's still on the dependency list, cargo is still trying to build it for `wasm32-unknown-unknown`, and it's failing pretty hard, obviously. This is the _one_ thing keeping me from building my parser for my toy language for wasm32-unknown-unknown. I patched to this branch and it works perfectly (or at least it compiles, I haven't actually hooked stuff up yet).