### PR TITLE
fallback: fix unaligned read

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -334,7 +334,7 @@ unsafe fn ptr_sub(ptr: *const u8, amt: usize) -> *const u8 {
 
 unsafe fn read_unaligned_usize(ptr: *const u8) -> usize {
     let mut n: usize = 0;
-    ptr::copy_nonoverlapping(ptr as *const usize, &mut n, USIZE_BYTES);
+    ptr::copy_nonoverlapping(ptr, &mut n as *mut _ as *mut u8, USIZE_BYTES);
     n
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ pub fn memchr3(
 ///
 /// This shows how to find the last position of a byte in a byte string.
 ///
-/// ```ignore
+/// ```
 /// use memchr::memrchr;
 ///
 /// let haystack = b"the quick brown fox";


### PR DESCRIPTION
This commit fixes a bug that caused undefined behavior by doing an
aligned read when an unaligned read was intended. In particular, we were
casting a `*const u8` to a `*const usize` and then reading its contents
to a `*mut usize`. The correct implementation is to reverse this such
that we read directly from `*const u8` and write to `*mut u8`, such that
ptr::copy_nonoverlapping knows to emit an unaligned load from the
`*const u8` pointer.