### PR TITLE
Add support for x86_64-fortanix-unknown-sgx target

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub use iter::{Memchr, Memchr2, Memchr3};
 #[cfg(all(
     feature = "libc",
     not(target_arch = "wasm32"),
+    not(target_env = "sgx"),
 ))]
 mod c;
 #[allow(dead_code)]
@@ -143,6 +144,7 @@ pub fn memchr(needle: u8, haystack: &[u8]) -> Option<usize> {
             feature = "libc",
             not(target_arch = "wasm32"),
             not(target_arch = "windows"),
+            not(target_env = "sgx"),
         ))] {
             #[inline(always)]
             fn imp(n1: u8, haystack: &[u8]) -> Option<usize> {
@@ -246,6 +248,7 @@ pub fn memrchr(needle: u8, haystack: &[u8]) -> Option<usize> {
             target_os = "linux",
             not(target_arch = "wasm32"),
             not(target_arch = "windows"),
+            not(target_env = "sgx"),
         ))] {
             #[inline(always)]
             fn imp(n1: u8, haystack: &[u8]) -> Option<usize> {


### PR DESCRIPTION
The `x86_64-fortanix-unknown-sgx` recently gained [Tier 3 support](https://forge.rust-lang.org/platform-support.html) upstream.