### PR TITLE
ci: test on big endian

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,11 @@ matrix:
     - os: linux
       rust: 1.13.0
       env: TARGET=x86_64-unknown-linux-gnu
+    # For testing big-endian.
+    - env: TARGET=mips64-unknown-linux-gnuabi64 CROSS=1
+      rust: stable
+      services: docker
+      sudo: required
 script: ci/script.sh
 branches:
   only:

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -3,6 +3,18 @@ use std::iter::repeat;
 mod iter;
 mod memchr;
 
+#[cfg(target_endian = "little")]
+#[test]
+fn byte_order() {
+    eprintln!("LITTLE ENDIAN");
+}
+
+#[cfg(target_endian = "big")]
+#[test]
+fn byte_order() {
+    eprintln!("BIG ENDIAN");
+}
+
 /// Create a sequence of tests that should be run by memchr implementations.
 fn memchr_tests() -> Vec<MemchrTest> {
     let mut tests = Vec::new();


### PR DESCRIPTION
There is a hypothesis that the memchr rewrite from a while back is
getting things wrong on big endian, as shown here:
https://github.com/BurntSushi/ripgrep/issues/1144

As a result, we start testing in CI on a big endian architecture.