### PR TITLE
Fix duplicated typo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,7 +222,7 @@ pub fn memchr3(
 ///
 /// While this is operationally the same as something like
 /// `haystack.iter().rposition(|&b| b == needle)`, `memrchr` will use a highly
-/// optimized routine that can be up to an order of magnitude master in some
+/// optimized routine that can be up to an order of magnitude faster in some
 /// cases.
 ///
 /// # Example


### PR DESCRIPTION
This is a duplicate of typo fixed in #40, the comment seems to also have
been a copy from the very similar method. See closed prematurely closed #41. :smile: 