### PR TITLE
Speed up multiple nibble searches

### DIFF
--- a/bench/Cargo.lock
+++ b/bench/Cargo.lock
@@ -174,10 +174,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "memchr"
 version = "2.1.3"
-
-[[package]]
-name = "memchr"
-version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -185,12 +181,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.2.0"
+
+[[package]]
 name = "memchr-bench"
 version = "0.0.1"
 dependencies = [
  "criterion 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
- "memchr 2.1.3",
+ "memchr 2.2.0",
 ]
 
 [[package]]

--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -642,9 +642,7 @@ fn forward_pos(mask: i32) -> usize {
 fn forward_pos2(mask1: i32, mask2: i32) -> usize {
     debug_assert!(mask1 != 0 || mask2 != 0);
 
-    let i1 = forward_pos(mask1);
-    let i2 = forward_pos(mask2);
-    if i1 < i2 { i1 } else { i2 }
+    forward_pos(mask1 | mask2)
 }
 
 /// Compute the position of the first matching byte from the given masks. The
@@ -656,16 +654,7 @@ fn forward_pos2(mask1: i32, mask2: i32) -> usize {
 fn forward_pos3(mask1: i32, mask2: i32, mask3: i32) -> usize {
     debug_assert!(mask1 != 0 || mask2 != 0 || mask3 != 0);
 
-    let i1 = forward_pos(mask1);
-    let i2 = forward_pos(mask2);
-    let i3 = forward_pos(mask3);
-    if i1 < i2 && i1 < i3 {
-        i1
-    } else if i2 < i3 {
-        i2
-    } else {
-        i3
-    }
+    forward_pos(mask1 | mask2 | mask3)
 }
 
 /// Compute the position of the last matching byte from the given mask. The
@@ -691,15 +680,7 @@ fn reverse_pos(mask: i32) -> usize {
 fn reverse_pos2(mask1: i32, mask2: i32) -> usize {
     debug_assert!(mask1 != 0 || mask2 != 0);
 
-    if mask1 == 0 {
-        reverse_pos(mask2)
-    } else if mask2 == 0 {
-        reverse_pos(mask1)
-    } else {
-        let i1 = reverse_pos(mask1);
-        let i2 = reverse_pos(mask2);
-        if i1 > i2 { i1 } else { i2 }
-    }
+    reverse_pos(mask1 | mask2)
 }
 
 /// Compute the position of the last matching byte from the given masks. The
@@ -711,24 +692,7 @@ fn reverse_pos2(mask1: i32, mask2: i32) -> usize {
 fn reverse_pos3(mask1: i32, mask2: i32, mask3: i32) -> usize {
     debug_assert!(mask1 != 0 || mask2 != 0 || mask3 != 0);
 
-    if mask1 == 0 {
-        reverse_pos2(mask2, mask3)
-    } else if mask2 == 0 {
-        reverse_pos2(mask1, mask3)
-    } else if mask3 == 0 {
-        reverse_pos2(mask1, mask2)
-    } else {
-        let i1 = reverse_pos(mask1);
-        let i2 = reverse_pos(mask2);
-        let i3 = reverse_pos(mask3);
-        if i1 > i2 && i1 > i3 {
-            i1
-        } else if i2 > i3 {
-            i2
-        } else {
-            i3
-        }
-    }
+    reverse_pos(mask1 | mask2 | mask3)
 }
 
 /// Subtract `b` from `a` and return the difference. `a` should be greater than

--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -730,9 +730,7 @@ fn forward_pos(mask: i32) -> usize {
 fn forward_pos2(mask1: i32, mask2: i32) -> usize {
     debug_assert!(mask1 != 0 || mask2 != 0);
 
-    let i1 = forward_pos(mask1);
-    let i2 = forward_pos(mask2);
-    if i1 < i2 { i1 } else { i2 }
+    forward_pos(mask1 | mask2)
 }
 
 /// Compute the position of the first matching byte from the given masks. The
@@ -744,16 +742,7 @@ fn forward_pos2(mask1: i32, mask2: i32) -> usize {
 fn forward_pos3(mask1: i32, mask2: i32, mask3: i32) -> usize {
     debug_assert!(mask1 != 0 || mask2 != 0 || mask3 != 0);
 
-    let i1 = forward_pos(mask1);
-    let i2 = forward_pos(mask2);
-    let i3 = forward_pos(mask3);
-    if i1 < i2 && i1 < i3 {
-        i1
-    } else if i2 < i3 {
-        i2
-    } else {
-        i3
-    }
+    forward_pos(mask1 | mask2 | mask3)
 }
 
 /// Compute the position of the last matching byte from the given mask. The
@@ -779,15 +768,7 @@ fn reverse_pos(mask: i32) -> usize {
 fn reverse_pos2(mask1: i32, mask2: i32) -> usize {
     debug_assert!(mask1 != 0 || mask2 != 0);
 
-    if mask1 == 0 {
-        reverse_pos(mask2)
-    } else if mask2 == 0 {
-        reverse_pos(mask1)
-    } else {
-        let i1 = reverse_pos(mask1);
-        let i2 = reverse_pos(mask2);
-        if i1 > i2 { i1 } else { i2 }
-    }
+    reverse_pos(mask1 | mask2)
 }
 
 /// Compute the position of the last matching byte from the given masks. The
@@ -799,24 +780,7 @@ fn reverse_pos2(mask1: i32, mask2: i32) -> usize {
 fn reverse_pos3(mask1: i32, mask2: i32, mask3: i32) -> usize {
     debug_assert!(mask1 != 0 || mask2 != 0 || mask3 != 0);
 
-    if mask1 == 0 {
-        reverse_pos2(mask2, mask3)
-    } else if mask2 == 0 {
-        reverse_pos2(mask1, mask3)
-    } else if mask3 == 0 {
-        reverse_pos2(mask1, mask2)
-    } else {
-        let i1 = reverse_pos(mask1);
-        let i2 = reverse_pos(mask2);
-        let i3 = reverse_pos(mask3);
-        if i1 > i2 && i1 > i3 {
-            i1
-        } else if i2 > i3 {
-            i2
-        } else {
-            i3
-        }
-    }
+    reverse_pos(mask1 | mask2 | mask3)
 }
 
 /// Subtract `b` from `a` and return the difference. `a` should be greater than


### PR DESCRIPTION
Simplify `forward_pos[23]` / `reverse_pos[23]` by ORing masks.

I believe I am missing something because compared to all the SIMD optimizations it looks very simple. Anyway tests pass and benches show improvements so I wanted to share.

I got ~10-20% (up to 30%) speed ups on existing benches. Note that it is consistently slightly worse on the *never* tests, but the difference is small (1-2%) and on faster tests.

My machine is using AVX2, I am not sure for the other platform but I suppose it is ok.

<details><summary>memchr2/rust</summary>

```sh
memchr2/rust/huge/never time:   [18.858 us 18.954 us 19.117 us]
                        thrpt:  [28.984 GiB/s 29.232 GiB/s 29.381 GiB/s]
                 change:
                        time:   [-6.6607% -3.7235% -1.2840%] (p = 0.00 < 0.05)
                        thrpt:  [+1.3007% +3.8675% +7.1361%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low severe
  4 (4.00%) low mild
  2 (2.00%) high mild
  5 (5.00%) high severe

memchr2/rust/huge/rare  time:   [23.723 us 23.787 us 23.877 us]
                        thrpt:  [23.205 GiB/s 23.293 GiB/s 23.356 GiB/s]
                 change:
                        time:   [-2.2050% -1.5797% -1.0051%] (p = 0.00 < 0.05)
                        thrpt:  [+1.0153% +1.6050% +2.2547%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  4 (4.00%) low mild
  2 (2.00%) high mild
  6 (6.00%) high severe

memchr2/rust/huge/uncommon
                        time:   [236.11 us 236.31 us 236.50 us]
                        thrpt:  [2.3428 GiB/s 2.3447 GiB/s 2.3467 GiB/s]
                 change:
                        time:   [-17.148% -16.823% -16.503%] (p = 0.00 < 0.05)
                        thrpt:  [+19.765% +20.225% +20.697%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) low mild
  2 (2.00%) high mild
  1 (1.00%) high severe

memchr2/rust/huge/common
                        time:   [638.74 us 639.39 us 640.04 us]
                        thrpt:  [886.47 MiB/s 887.37 MiB/s 888.27 MiB/s]
                 change:
                        time:   [-20.406% -20.185% -19.977%] (p = 0.00 < 0.05)
                        thrpt:  [+24.964% +25.290% +25.637%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high severe

memchr2/rust/small/never
                        time:   [20.977 ns 21.002 ns 21.029 ns]
                        thrpt:  [29.407 GiB/s 29.444 GiB/s 29.480 GiB/s]
                 change:
                        time:   [-5.9833% -4.3093% -2.8920%] (p = 0.00 < 0.05)
                        thrpt:  [+2.9782% +4.5034% +6.3641%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

memchr2/rust/small/rare time:   [37.847 ns 37.881 ns 37.913 ns]
                        thrpt:  [16.311 GiB/s 16.325 GiB/s 16.340 GiB/s]
                 change:
                        time:   [-1.6847% -1.2662% -0.8068%] (p = 0.00 < 0.05)
                        thrpt:  [+0.8134% +1.2824% +1.7135%]
                        Change within noise threshold.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

memchr2/rust/small/uncommon
                        time:   [165.09 ns 165.28 ns 165.50 ns]
                        thrpt:  [3.7365 GiB/s 3.7415 GiB/s 3.7459 GiB/s]
                 change:
                        time:   [-3.0530% -2.6098% -2.2052%] (p = 0.00 < 0.05)
                        thrpt:  [+2.2549% +2.6797% +3.1491%]
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe

memchr2/rust/small/common
                        time:   [642.77 ns 644.35 ns 646.64 ns]
                        thrpt:  [979.28 MiB/s 982.76 MiB/s 985.18 MiB/s]
                 change:
                        time:   [-7.7038% -7.3108% -6.8485%] (p = 0.00 < 0.05)
                        thrpt:  [+7.3520% +7.8874% +8.3468%]
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe

memchr2/rust/tiny/never time:   [7.9616 ns 7.9792 ns 8.0073 ns]
                        thrpt:  [8.0253 GiB/s 8.0535 GiB/s 8.0714 GiB/s]
                 change:
                        time:   [+2.8953% +3.4635% +4.0231%] (p = 0.00 < 0.05)
                        thrpt:  [-3.8675% -3.3476% -2.8138%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe

memchr2/rust/tiny/rare  time:   [15.892 ns 15.911 ns 15.930 ns]
                        thrpt:  [4.0340 GiB/s 4.0389 GiB/s 4.0437 GiB/s]
                 change:
                        time:   [-14.113% -13.785% -13.469%] (p = 0.00 < 0.05)
                        thrpt:  [+15.565% +15.989% +16.432%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  3 (3.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe

memchr2/rust/tiny/uncommon
                        time:   [83.028 ns 83.200 ns 83.461 ns]
                        thrpt:  [788.44 MiB/s 790.91 MiB/s 792.55 MiB/s]
                 change:
                        time:   [-11.878% -11.417% -11.011%] (p = 0.00 < 0.05)
                        thrpt:  [+12.373% +12.888% +13.479%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  5 (5.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe

memchr2/rust/empty/never
                        time:   [730.81 ps 734.85 ps 740.03 ps]
                        thrpt:  [0.0000   B/s 0.0000   B/s 0.0000   B/s]
                 change:
                        time:   [-1.0110% -0.2935% +0.4390%] (p = 0.45 > 0.05)
                        thrpt:  [-0.4371% +0.2943% +1.0213%]
                        No change in performance detected.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) high mild
  5 (5.00%) high severe
```

</details>

<details><summary>memchr3/rust</summary>

```sh
memchr3/rust/huge/never time:   [22.871 us 22.899 us 22.930 us]
                        thrpt:  [24.164 GiB/s 24.196 GiB/s 24.226 GiB/s]
                 change:
                        time:   [+1.0057% +1.4092% +1.7649%] (p = 0.00 < 0.05)
                        thrpt:  [-1.7343% -1.3897% -0.9957%]
                        Performance has regressed.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) high mild
  4 (4.00%) high severe

memchr3/rust/huge/rare  time:   [30.239 us 30.264 us 30.290 us]
                        thrpt:  [18.292 GiB/s 18.308 GiB/s 18.323 GiB/s]
                 change:
                        time:   [-2.1453% -1.2613% -0.6334%] (p = 0.00 < 0.05)
                        thrpt:  [+0.6374% +1.2775% +2.1923%]
                        Change within noise threshold.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) low mild
  1 (1.00%) high mild
  1 (1.00%) high severe

memchr3/rust/huge/uncommon
                        time:   [317.73 us 318.72 us 320.41 us]
                        thrpt:  [1.7292 GiB/s 1.7384 GiB/s 1.7439 GiB/s]
                 change:
                        time:   [-26.016% -25.666% -25.269%] (p = 0.00 < 0.05)
                        thrpt:  [+33.814% +34.528% +35.164%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) high mild
  4 (4.00%) high severe

memchr3/rust/huge/common
                        time:   [961.46 us 962.31 us 963.19 us]
                        thrpt:  [589.05 MiB/s 589.59 MiB/s 590.12 MiB/s]
                 change:
                        time:   [-25.568% -25.066% -24.766%] (p = 0.00 < 0.05)
                        thrpt:  [+32.919% +33.451% +34.351%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild

memchr3/rust/small/never
                        time:   [24.971 ns 24.990 ns 25.010 ns]
                        thrpt:  [24.726 GiB/s 24.746 GiB/s 24.765 GiB/s]
                 change:
                        time:   [+2.7118% +2.9179% +3.1205%] (p = 0.00 < 0.05)
                        thrpt:  [-3.0261% -2.8352% -2.6402%]
                        Performance has regressed.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

memchr3/rust/small/rare time:   [53.630 ns 53.703 ns 53.777 ns]
                        thrpt:  [11.499 GiB/s 11.515 GiB/s 11.531 GiB/s]
                 change:
                        time:   [-8.4764% -7.4002% -6.6152%] (p = 0.00 < 0.05)
                        thrpt:  [+7.0838% +7.9916% +9.2614%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  2 (2.00%) low mild
  3 (3.00%) high mild

memchr3/rust/small/uncommon
                        time:   [244.34 ns 245.72 ns 248.31 ns]
                        thrpt:  [2.4904 GiB/s 2.5167 GiB/s 2.5309 GiB/s]
                 change:
                        time:   [-13.474% -11.639% -10.207%] (p = 0.00 < 0.05)
                        thrpt:  [+11.367% +13.172% +15.572%]
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  3 (3.00%) high mild
  3 (3.00%) high severe

memchr3/rust/small/common
                        time:   [969.74 ns 970.91 ns 972.13 ns]
                        thrpt:  [651.40 MiB/s 652.21 MiB/s 653.00 MiB/s]
                 change:
                        time:   [-11.454% -11.059% -10.731%] (p = 0.00 < 0.05)
                        thrpt:  [+12.021% +12.434% +12.936%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

memchr3/rust/tiny/never time:   [7.7085 ns 7.7267 ns 7.7448 ns]
                        thrpt:  [8.2974 GiB/s 8.3168 GiB/s 8.3364 GiB/s]
                 change:
                        time:   [-3.6148% -3.2560% -2.8888%] (p = 0.00 < 0.05)
                        thrpt:  [+2.9748% +3.3656% +3.7504%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe

memchr3/rust/tiny/rare  time:   [27.601 ns 27.629 ns 27.656 ns]
                        thrpt:  [2.3236 GiB/s 2.3259 GiB/s 2.3283 GiB/s]
                 change:
                        time:   [-17.975% -17.693% -17.452%] (p = 0.00 < 0.05)
                        thrpt:  [+21.141% +21.496% +21.913%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) low mild
  5 (5.00%) high mild
  2 (2.00%) high severe

memchr3/rust/tiny/uncommon
                        time:   [117.90 ns 118.32 ns 118.77 ns]
                        thrpt:  [554.04 MiB/s 556.16 MiB/s 558.11 MiB/s]
                 change:
                        time:   [-11.156% -10.725% -10.235%] (p = 0.00 < 0.05)
                        thrpt:  [+11.402% +12.014% +12.557%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe

memchr3/rust/empty/never
                        time:   [729.84 ps 733.96 ps 738.77 ps]
                        thrpt:  [0.0000   B/s 0.0000   B/s 0.0000   B/s]
                 change:
                        time:   [-0.9110% +0.4612% +1.5081%] (p = 0.52 > 0.05)
                        thrpt:  [-1.4857% -0.4591% +0.9194%]
                        No change in performance detected.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe
```

</details>



<details><summary>memrchr2/rust</summary>

```sh

memrchr2/rust/huge/never
                        time:   [18.848 us 18.869 us 18.889 us]
                        thrpt:  [29.333 GiB/s 29.364 GiB/s 29.396 GiB/s]
                 change:
                        time:   [-0.5288% +0.0018% +0.4375%] (p = 0.99 > 0.05)
                        thrpt:  [-0.4356% -0.0018% +0.5316%]
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

memrchr2/rust/huge/rare time:   [23.712 us 23.743 us 23.782 us]
                        thrpt:  [23.298 GiB/s 23.336 GiB/s 23.367 GiB/s]
                 change:
                        time:   [-1.7340% -1.2820% -0.7603%] (p = 0.00 < 0.05)
                        thrpt:  [+0.7661% +1.2986% +1.7646%]
                        Change within noise threshold.
Found 9 outliers among 100 measurements (9.00%)
  4 (4.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe

memrchr2/rust/huge/uncommon
                        time:   [233.82 us 234.11 us 234.41 us]
                        thrpt:  [2.3637 GiB/s 2.3668 GiB/s 2.3696 GiB/s]
                 change:
                        time:   [-14.889% -14.666% -14.458%] (p = 0.00 < 0.05)
                        thrpt:  [+16.901% +17.187% +17.494%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  4 (4.00%) low mild
  1 (1.00%) high mild
  3 (3.00%) high severe

memrchr2/rust/huge/common
                        time:   [653.23 us 653.92 us 654.59 us]
                        thrpt:  [866.76 MiB/s 867.65 MiB/s 868.56 MiB/s]
                 change:
                        time:   [-22.013% -21.799% -21.594%] (p = 0.00 < 0.05)
                        thrpt:  [+27.541% +27.875% +28.227%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe

memrchr2/rust/small/never
                        time:   [20.359 ns 20.394 ns 20.439 ns]
                        thrpt:  [30.256 GiB/s 30.323 GiB/s 30.374 GiB/s]
                 change:
                        time:   [-2.2206% -1.4895% -0.6582%] (p = 0.00 < 0.05)
                        thrpt:  [+0.6626% +1.5121% +2.2710%]
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

memrchr2/rust/small/rare
                        time:   [37.696 ns 37.737 ns 37.779 ns]
                        thrpt:  [16.369 GiB/s 16.387 GiB/s 16.405 GiB/s]
                 change:
                        time:   [-5.8363% -2.3832% +0.5340%] (p = 0.17 > 0.05)
                        thrpt:  [-0.5312% +2.4414% +6.1980%]
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe

memrchr2/rust/small/uncommon
                        time:   [154.64 ns 154.91 ns 155.28 ns]
                        thrpt:  [3.9826 GiB/s 3.9920 GiB/s 3.9991 GiB/s]
                 change:
                        time:   [-1.4091% -0.1348% +0.9244%] (p = 0.84 > 0.05)
                        thrpt:  [-0.9159% +0.1349% +1.4293%]
                        No change in performance detected.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high severe

memrchr2/rust/small/common
                        time:   [702.94 ns 703.97 ns 705.09 ns]
                        thrpt:  [898.10 MiB/s 899.53 MiB/s 900.84 MiB/s]
                 change:
                        time:   [-10.065% -9.1618% -8.3306%] (p = 0.00 < 0.05)
                        thrpt:  [+9.0876% +10.086% +11.191%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) low mild
  4 (4.00%) high mild
  2 (2.00%) high severe

memrchr2/rust/tiny/never
                        time:   [7.2781 ns 7.2910 ns 7.3059 ns]
                        thrpt:  [8.7958 GiB/s 8.8138 GiB/s 8.8295 GiB/s]
                 change:
                        time:   [-9.3342% -8.6906% -8.0693%] (p = 0.00 < 0.05)
                        thrpt:  [+8.7776% +9.5177% +10.295%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

memrchr2/rust/tiny/rare time:   [23.962 ns 24.005 ns 24.050 ns]
                        thrpt:  [2.6720 GiB/s 2.6770 GiB/s 2.6818 GiB/s]
                 change:
                        time:   [-3.3619% -2.1260% -0.5604%] (p = 0.00 < 0.05)
                        thrpt:  [+0.5636% +2.1722% +3.4788%]
                        Change within noise threshold.
Found 4 outliers among 100 measurements (4.00%)
  4 (4.00%) high severe

memrchr2/rust/tiny/uncommon
                        time:   [77.028 ns 77.103 ns 77.178 ns]
                        thrpt:  [852.62 MiB/s 853.44 MiB/s 854.29 MiB/s]
                 change:
                        time:   [-8.9449% -8.5884% -8.2295%] (p = 0.00 < 0.05)
                        thrpt:  [+8.9675% +9.3953% +9.8236%]
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  1 (1.00%) high mild
  2 (2.00%) high severe

memrchr2/rust/empty/never
                        time:   [2.2967 ns 2.3161 ns 2.3362 ns]
                        thrpt:  [0.0000   B/s 0.0000   B/s 0.0000   B/s]
                 change:
                        time:   [-2.7450% -1.2852% +0.2843%] (p = 0.09 > 0.05)
                        thrpt:  [-0.2835% +1.3019% +2.8224%]
                        No change in performance detected.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

```

</details>

<details><summary>memrchr3/rust</summary>

```sh

memrchr3/rust/huge/never
                        time:   [23.607 us 23.793 us 24.018 us]
                        thrpt:  [23.069 GiB/s 23.288 GiB/s 23.471 GiB/s]
                 change:
                        time:   [+1.4092% +2.5373% +3.7526%] (p = 0.00 < 0.05)
                        thrpt:  [-3.6168% -2.4745% -1.3896%]
                        Performance has regressed.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

memrchr3/rust/huge/rare time:   [31.398 us 31.768 us 32.242 us]
                        thrpt:  [17.185 GiB/s 17.441 GiB/s 17.647 GiB/s]
                 change:
                        time:   [+3.2742% +5.3215% +8.2700%] (p = 0.00 < 0.05)
                        thrpt:  [-7.6383% -5.0527% -3.1704%]
                        Performance has regressed.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

memrchr3/rust/huge/uncommon
                        time:   [323.09 us 324.97 us 327.26 us]
                        thrpt:  [1.6931 GiB/s 1.7050 GiB/s 1.7149 GiB/s]
                 change:
                        time:   [-25.721% -25.385% -25.032%] (p = 0.00 < 0.05)
                        thrpt:  [+33.390% +34.021% +34.628%]
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  2 (2.00%) high mild
  7 (7.00%) high severe

memrchr3/rust/huge/common
                        time:   [999.72 us 1.0022 ms 1.0050 ms]
                        thrpt:  [564.54 MiB/s 566.15 MiB/s 567.53 MiB/s]
                 change:
                        time:   [-32.037% -31.654% -31.293%] (p = 0.00 < 0.05)
                        thrpt:  [+45.546% +46.315% +47.139%]
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  2 (2.00%) high mild
  6 (6.00%) high severe

memrchr3/rust/small/never
                        time:   [25.959 ns 26.086 ns 26.239 ns]
                        thrpt:  [23.567 GiB/s 23.706 GiB/s 23.822 GiB/s]
                 change:
                        time:   [+3.3337% +3.9145% +4.5849%] (p = 0.00 < 0.05)
                        thrpt:  [-4.3839% -3.7670% -3.2261%]
                        Performance has regressed.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

memrchr3/rust/small/rare
                        time:   [52.927 ns 53.178 ns 53.469 ns]
                        thrpt:  [11.566 GiB/s 11.629 GiB/s 11.684 GiB/s]
                 change:
                        time:   [-9.8604% -7.6728% -5.7200%] (p = 0.00 < 0.05)
                        thrpt:  [+6.0670% +8.3104% +10.939%]
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe

memrchr3/rust/small/uncommon
                        time:   [239.82 ns 240.85 ns 241.99 ns]
                        thrpt:  [2.5554 GiB/s 2.5676 GiB/s 2.5786 GiB/s]
                 change:
                        time:   [-9.3766% -7.9175% -6.5700%] (p = 0.00 < 0.05)
                        thrpt:  [+7.0320% +8.5983% +10.347%]
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  5 (5.00%) high mild
  5 (5.00%) high severe

memrchr3/rust/small/common
                        time:   [1.0297 us 1.0328 us 1.0370 us]
                        thrpt:  [610.66 MiB/s 613.10 MiB/s 614.97 MiB/s]
                 change:
                        time:   [-26.141% -25.564% -24.867%] (p = 0.00 < 0.05)
                        thrpt:  [+33.098% +34.343% +35.393%]
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  2 (2.00%) high mild
  2 (2.00%) high severe

memrchr3/rust/tiny/never
                        time:   [8.7131 ns 8.7272 ns 8.7426 ns]
                        thrpt:  [7.3503 GiB/s 7.3633 GiB/s 7.3753 GiB/s]
                 change:
                        time:   [+4.1245% +4.5688% +4.9012%] (p = 0.00 < 0.05)
                        thrpt:  [-4.6722% -4.3691% -3.9611%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  2 (2.00%) high mild
  1 (1.00%) high severe

memrchr3/rust/tiny/rare time:   [26.131 ns 26.162 ns 26.195 ns]
                        thrpt:  [2.4532 GiB/s 2.4562 GiB/s 2.4592 GiB/s]
                 change:
                        time:   [-17.361% -16.969% -16.581%] (p = 0.00 < 0.05)
                        thrpt:  [+19.877% +20.438% +21.008%]
                        Performance has improved.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

memrchr3/rust/tiny/uncommon
                        time:   [124.05 ns 124.26 ns 124.48 ns]
                        thrpt:  [528.62 MiB/s 529.55 MiB/s 530.47 MiB/s]
                 change:
                        time:   [-24.539% -23.091% -22.105%] (p = 0.00 < 0.05)
                        thrpt:  [+28.377% +30.024% +32.519%]
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

memrchr3/rust/empty/never
                        time:   [2.1768 ns 2.1801 ns 2.1837 ns]
                        thrpt:  [0.0000   B/s 0.0000   B/s 0.0000   B/s]
                 change:
                        time:   [-0.5848% -0.1705% +0.1886%] (p = 0.41 > 0.05)
                        thrpt:  [-0.1882% +0.1708% +0.5883%]
                        No change in performance detected.
Found 4 outliers among 100 measurements (4.00%)
  1 (1.00%) high mild
  3 (3.00%) high severe

```

</details>