### PR TITLE
Support target_pointer_width less than 32

### DIFF
--- a/src/fallback.rs
+++ b/src/fallback.rs
@@ -6,6 +6,12 @@ use core::cmp;
 use core::ptr;
 use core::usize;
 
+#[cfg(target_pointer_width = "8")]
+const USIZE_BYTES: usize = 1;
+
+#[cfg(target_pointer_width = "16")]
+const USIZE_BYTES: usize = 2;
+
 #[cfg(target_pointer_width = "32")]
 const USIZE_BYTES: usize = 4;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,11 +25,6 @@ instead of one. Similarly for `memchr3`.
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/memchr/2.0.0")]
 
-// Supporting 16-bit would be fine. If you need it, please submit a bug report
-// at https://github.com/BurntSushi/rust-memchr
-#[cfg(not(any(target_pointer_width = "32", target_pointer_width = "64")))]
-compile_error!("memchr currently not supported on non-32 or non-64 bit");
-
 #[cfg(feature = "use_std")]
 extern crate core;
 


### PR DESCRIPTION
My use-case for this is using the library for an avr target, and it seemed quite easy to get the fallback working for that use-case.