### PR TITLE
simd: Remove redundant block in memchr3

### DIFF
--- a/src/x86/avx.rs
+++ b/src/x86/avx.rs
@@ -226,14 +226,6 @@ pub unsafe fn memchr3(
             let mask1 = _mm256_movemask_epi8(eqb1);
             let mask2 = _mm256_movemask_epi8(eqb2);
             let mask3 = _mm256_movemask_epi8(eqb3);
-            if mask1 != 0 || mask2 != 0 || mask3 != 0 {
-                return Some(at + forward_pos3(mask1, mask2, mask3));
-            }
-
-            at += VECTOR_SIZE;
-            let mask1 = _mm256_movemask_epi8(eqb1);
-            let mask2 = _mm256_movemask_epi8(eqb2);
-            let mask3 = _mm256_movemask_epi8(eqb3);
             return Some(at + forward_pos3(mask1, mask2, mask3));
         }
         ptr = ptr.add(loop_size);

--- a/src/x86/sse2.rs
+++ b/src/x86/sse2.rs
@@ -314,14 +314,6 @@ pub unsafe fn memchr3(
             let mask1 = _mm_movemask_epi8(eqb1);
             let mask2 = _mm_movemask_epi8(eqb2);
             let mask3 = _mm_movemask_epi8(eqb3);
-            if mask1 != 0 || mask2 != 0 || mask3 != 0 {
-                return Some(at + forward_pos3(mask1, mask2, mask3));
-            }
-
-            at += VECTOR_SIZE;
-            let mask1 = _mm_movemask_epi8(eqb1);
-            let mask2 = _mm_movemask_epi8(eqb2);
-            let mask3 = _mm_movemask_epi8(eqb3);
             return Some(at + forward_pos3(mask1, mask2, mask3));
         }
         ptr = ptr.add(loop_size);


### PR DESCRIPTION
In the sse2 and avx implementation of memchr3.

The memchr3 steps by two vector-sizes at time. When a match was found in
one of them, it would check the first one first, then the second one and
then the second one again.

It wasn't causing any incorrect behavior, but did extra work unless
compiler optimized it away.