### PR TITLE
Run libc benchmarks on non-x86_64 archs as well

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -19,9 +19,7 @@ path = "src/bench.rs"
 [dependencies]
 criterion = "0.2"
 memchr = { version = "*", path = ".." }
-
-[target.'cfg(target_arch = "x86_64")'.dependencies.libc]
-version = "0.2.18"
+libc = "0.2.18"
 
 [profile.release]
 debug = true

--- a/bench/src/bench.rs
+++ b/bench/src/bench.rs
@@ -1,7 +1,6 @@
 extern crate core;
 #[macro_use]
 extern crate criterion;
-#[cfg(target_arch = "x86_64")]
 extern crate libc;
 extern crate memchr;
 
@@ -14,7 +13,6 @@ use imp::{
 };
 use inputs::{Input, Search1, Search2, Search3, EMPTY, HUGE, SMALL, TINY};
 
-#[cfg(target_arch = "x86_64")]
 #[path = "../../src/c.rs"]
 mod c;
 #[path = "../../src/fallback.rs"]
@@ -59,41 +57,38 @@ fn all(c: &mut Criterion) {
         });
     });
 
-    #[cfg(target_arch = "x86_64")]
-    {
-        define_input1(c, "memchr1/libc/huge", HUGE, move |search, b| {
-            b.iter(|| {
-                assert_eq!(
-                    search.byte1.count,
-                    imp::memchr1_libc_count(search.byte1.byte, search.corpus),
-                );
-            });
+    define_input1(c, "memchr1/libc/huge", HUGE, move |search, b| {
+        b.iter(|| {
+            assert_eq!(
+                search.byte1.count,
+                imp::memchr1_libc_count(search.byte1.byte, search.corpus),
+            );
         });
-        define_input1(c, "memchr1/libc/small", SMALL, move |search, b| {
-            b.iter(|| {
-                assert_eq!(
-                    search.byte1.count,
-                    imp::memchr1_libc_count(search.byte1.byte, search.corpus),
-                );
-            });
+    });
+    define_input1(c, "memchr1/libc/small", SMALL, move |search, b| {
+        b.iter(|| {
+            assert_eq!(
+                search.byte1.count,
+                imp::memchr1_libc_count(search.byte1.byte, search.corpus),
+            );
         });
-        define_input1(c, "memchr1/libc/tiny", TINY, move |search, b| {
-            b.iter(|| {
-                assert_eq!(
-                    search.byte1.count,
-                    imp::memchr1_libc_count(search.byte1.byte, search.corpus),
-                );
-            });
+    });
+    define_input1(c, "memchr1/libc/tiny", TINY, move |search, b| {
+        b.iter(|| {
+            assert_eq!(
+                search.byte1.count,
+                imp::memchr1_libc_count(search.byte1.byte, search.corpus),
+            );
         });
-        define_input1(c, "memchr1/libc/empty", EMPTY, move |search, b| {
-            b.iter(|| {
-                assert_eq!(
-                    search.byte1.count,
-                    imp::memchr1_libc_count(search.byte1.byte, search.corpus),
-                );
-            });
+    });
+    define_input1(c, "memchr1/libc/empty", EMPTY, move |search, b| {
+        b.iter(|| {
+            assert_eq!(
+                search.byte1.count,
+                imp::memchr1_libc_count(search.byte1.byte, search.corpus),
+            );
         });
-    }
+    });
 
     define_input1(c, "memchr1/fallback/huge", HUGE, move |search, b| {
         b.iter(|| {
@@ -500,7 +495,7 @@ fn all(c: &mut Criterion) {
         });
     });
 
-    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    #[cfg(all(target_os = "linux"))]
     {
         define_input1(c, "memrchr1/libc/huge", HUGE, move |search, b| {
             b.iter(|| {

--- a/bench/src/imp.rs
+++ b/bench/src/imp.rs
@@ -1,4 +1,3 @@
-#[cfg(target_arch = "x86_64")]
 use c;
 use fallback;
 use memchr::{memrchr, memrchr2, memrchr3, Memchr, Memchr2, Memchr3};
@@ -8,7 +7,6 @@ pub fn memchr1_count(b1: u8, haystack: &[u8]) -> usize {
     Memchr::new(b1, haystack).count()
 }
 
-#[cfg(target_arch = "x86_64")]
 pub fn memchr1_libc_count(b1: u8, haystack: &[u8]) -> usize {
     let mut count = 0;
     let mut start = 0;
@@ -97,7 +95,7 @@ pub fn memrchr1_count(b1: u8, haystack: &[u8]) -> usize {
     count
 }
 
-#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[cfg(all(target_os = "linux"))]
 pub fn memrchr1_libc_count(b1: u8, haystack: &[u8]) -> usize {
     let mut count = 0;
     let mut end = haystack.len();


### PR DESCRIPTION
I am trying to add aarch64 neon simd implementations (no promises though) and for that I need to compare it to the libc implementation which is already using neon instructions.

I removed the x86_64 guards in the benchmark code and it seems to be working fine.