### PR TITLE
Only enable SIMD on targets which feature SSE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,23 @@ jobs:
       name: Run benchmarks as tests
       run: cargo bench --manifest-path bench/Cargo.toml --verbose -- --test
 
+  build-for-non_sse-target:
+    name: build for non-SSE target
+    runs-on: ubuntu-18.04
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v1
+      with:
+        fetch-depth: 1
+    - name: Install Rust
+      uses: actions-rs/toolchain@v1
+      with:
+        toolchain: nightly
+        profile: minimal
+        override: true
+        components: rust-src
+    - run: cargo build -Z build-std=core --target=src/tests/x86_64-soft_float.json --verbose --no-default-features
+
   test-with-miri:
     name: test with miri
     runs-on: ubuntu-18.04

--- a/build.rs
+++ b/build.rs
@@ -5,12 +5,19 @@ fn main() {
     enable_libc();
 }
 
-// This adds various simd cfgs if this compiler supports it.
+// This adds various simd cfgs if this compiler and target support it.
 //
 // This can be disabled with RUSTFLAGS="--cfg memchr_disable_auto_simd", but
 // this is generally only intended for testing.
+//
+// On targets which don't feature SSE2, this is disabled, as LLVM wouln't know
+// how to work with SSE2 operands. Enabling SSE4.2 and AVX on SSE2-only targets
+// is not a problem. In that case, the fastest option will be chosen at
+// runtime.
 fn enable_simd_optimizations() {
-    if is_env_set("CARGO_CFG_MEMCHR_DISABLE_AUTO_SIMD") {
+    if is_env_set("CARGO_CFG_MEMCHR_DISABLE_AUTO_SIMD")
+        || !target_has_feature("sse2")
+    {
         return;
     }
     println!("cargo:rustc-cfg=memchr_runtime_simd");
@@ -58,4 +65,10 @@ fn is_feature_set(name: &str) -> bool {
 
 fn is_env_set(name: &str) -> bool {
     env::var_os(name).is_some()
+}
+
+fn target_has_feature(feature: &str) -> bool {
+    env::var("CARGO_CFG_TARGET_FEATURE")
+        .map(|features| features.contains(feature))
+        .unwrap_or(false)
 }

--- a/src/tests/x86_64-soft_float.json
+++ b/src/tests/x86_64-soft_float.json
@@ -1,0 +1,15 @@
+{
+    "llvm-target": "x86_64-unknown-none",
+    "target-endian": "little",
+    "target-pointer-width": "64",
+    "target-c-int-width": "32",
+    "os": "none",
+    "arch": "x86_64",
+    "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128",
+    "linker-flavor": "ld.lld",
+    "linker": "rust-lld",
+    "features": "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-3dnow,-3dnowa,-avx,-avx2,+soft-float",
+    "executables": true,
+    "disable-redzone": true,
+    "panic-strategy": "abort"
+}


### PR DESCRIPTION
I just ran into issue #57, which is caused by compiling this crate for targets that do not support SSE instructions. This is common for operating system kernels.

I don't consume this crate directly but through a dependency. It would be nice to have this crate compile without having to manually specify `memchr_disable_auto_simd`.

This PR makes the build script check if the target supports SSE and disables SIMD optimizations if not.

What do you think?